### PR TITLE
Удалено чтение файлов README.rst и CHANGELOG.rst в setup.py, …

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[metadata]
+long_description = file: README.rst, CHANGELOG.rst
+long_description_content_type = text/x-rst; charset=UTF-8

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,10 @@
 from setuptools import find_packages, setup
 
-
-with open('README.rst', 'r') as readme:
-    long_description = readme.read()
-
-with open('CHANGELOG.rst', 'r') as changelog:
-    long_description += '\n\n' + changelog.read()
-
 setup(
     name='komtet_kassa_sdk',
     version='7.1.0',
     license='MIT',
     description='Python SDK for KOMTET Kassa',
-    long_description=long_description,
 
     author='Motmom',
     author_email='motmom.dev@gmail.com',


### PR DESCRIPTION
Чтение `long_description` (`README.rst` и `CHANGELOG.rst`) перенесено в `setup.cfg` с указанием кодировки.
Отсутствие указания кодировки `utf-8` на Windows вызывало `UnicodeDecodeError` при установке библиотеки.

Альтернативным вариантом является указание кодировки при открытии файлов
`with open('README.rst', 'r', encoding='utf-8') as readme:`
